### PR TITLE
Replace broken Soundcloud widget with a couple of working links.

### DIFF
--- a/listen.md
+++ b/listen.md
@@ -3,8 +3,7 @@ layout: sidebar_links
 title: Listen 
 ---
 
-These compositions have been made with help of Csound. To make your track listed here, add it to the Csound's SoundCloud group: [
-https://soundcloud.com/groups/csound](
-https://soundcloud.com/groups/csound)
+Some compositions that have been made with help of Csound can be found at these links:
+* <https://soundcloud.com/tags/csound>
+* <https://bandcamp.com/tag/csound>
 
-<iframe width="100%" height="450" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/groups/10104&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>


### PR DESCRIPTION
I tried to get something embedded working here, but was unsuccessful.
I think it's better to have something not broken here, even if it's just links.