### PR TITLE
corrected typo in month

### DIFF
--- a/_posts/2023-12-04-Csound-Conference-2024.md
+++ b/_posts/2023-12-04-Csound-Conference-2024.md
@@ -6,7 +6,7 @@ categories: site news
 ---
 
 The 7th international Csound Conference will take place in Vienna, Austria
-From November 17th to September 20th 2024.
+From September 17th to September 20th 2024.
 
 Webpage here: <https://mdw.ac.at/icsc2024/>
 

--- a/_posts/2023-12-04-Csound-Conference-2024.md
+++ b/_posts/2023-12-04-Csound-Conference-2024.md
@@ -13,7 +13,7 @@ Webpage here: <https://mdw.ac.at/icsc2024/>
 Important dates and deadlines (please check the website above for details and eventual updates):
 
 Conference:
-* Wednesday November 18 -— Friday November 20
+* Wednesday September 18 — Friday September 20
 * Opening Concert: Tuesday September 17
 
 Paper submissions


### PR DESCRIPTION
sorry, found a substantial typo (there was a 'November' in the dates left over from 2022)